### PR TITLE
fix the installation process of shiny server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ RUN apt-get update && apt-get install -y fonts-ipaexfont
 RUN Rscript -e "install.packages('githubinstall')"
 
 # Install Shiny server
-RUN export ADD=shiny && bash /etc/cont-init.d/add
+RUN /rocker_scripts/install_shiny_server.sh
 
 CMD ["/init"]


### PR DESCRIPTION
The scripts included in the base image `rocker/verse` have changed significantly since R4.0.0 and the installation process of shiny server needs to be modified. 

See https://github.com/rocker-org/rocker-versioned2#modifying-and-extending-images-in-the-new-architecture